### PR TITLE
Fixed npm bin script by adding a .js on the reference file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Configuration and scripts for kudobuzz projects",
   "bin": {
-    "kb-scripts": "bin/kb-scripts"
+    "kb-scripts": "bin/kb-scripts.js"
   },
   "scripts": {
     "lint": "node bin lint",


### PR DESCRIPTION
**Bug Fix:**   
Added .js extension on the bin property in package.json. Without it, npm installation of this package fails because the file is not found.